### PR TITLE
optimize: remove redundant type transfer for binary

### DIFF
--- a/validator/generator.go
+++ b/validator/generator.go
@@ -965,7 +965,7 @@ func (g *generator) generateSlice(st *golang.StructLike, name, typeID string, va
 			if val.ValueType == parser.FieldReferenceValue {
 				source = val.TypedValue.GetFieldReferenceName("p.", st)
 			} else {
-				source = "[]byte(\"" + val.TypedValue.Binary + "\")"
+				source = "\"" + val.TypedValue.Binary + "\""
 			}
 			vs = append(vs, typeid2go[typeID]+"("+source+")")
 		}


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
optimize
#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: remove redundant type transfer for binary
zh: 对于"binary"类型的"in/not_in"校验，去掉一次多余的"[]byte"类型转换

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
