### PR TITLE
feat: support vt.in and vt.not_in for enum validator

### DIFF
--- a/parser/annotation.go
+++ b/parser/annotation.go
@@ -128,6 +128,8 @@ var (
 		Const,
 		DefinedOnly,
 		NotNil,
+		In,
+		NotIn,
 	}
 	ListKeys = []Key{
 		MinSize,

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -112,7 +112,7 @@ func (p *Parser) parseEnum(st *tp.StructLike, annotations []*tp.Annotation) (*Va
 			}
 			if value == nil {
 				switch nodeKey {
-				case Const:
+				case Const, In, NotIn:
 					value = &ValidationValue{
 						ValueType:  BinaryValue,
 						TypedValue: TypedValidationValue{Binary: annoVal},


### PR DESCRIPTION
#### What type of PR is this?

feat

#### What this PR does / why we need it (en: English/zh: Chinese):
en: support vt.in and vt.not_in for enum validator
zh: 为枚举字段支持 vt.in 和 vt.not_in 校验能力

eg：
```
enum Type {
    Number, String, List, Map
}

struct EnumDemo {
    1:Type OptType (vt.not_in = "Type.List",vt.not_in = "Type.Number")
    2: Type OptType2 (vt.in = "Type.String",vt.in = "Type.List",)
}
```

#### Which issue(s) this PR fixes:

