### PR TITLE
fix: fix recursive request param

### DIFF
--- a/validator/generator.go
+++ b/validator/generator.go
@@ -116,7 +116,16 @@ func (g *generator) unindent() {
 func (g *generator) generate() ([]*plugin.Generated, error) {
 	var ret []*plugin.Generated
 	// generate file header
-	for ast := range g.request.AST.DepthFirstSearch() {
+	var trees chan *tp.Thrift
+	if g.request.Recursive {
+		trees = g.request.AST.DepthFirstSearch()
+	} else {
+		trees = make(chan *tp.Thrift, 1)
+		trees <- g.request.AST
+		close(trees)
+	}
+
+	for ast := range trees {
 		g.buffer.Reset()
 		g.enumImport = g.enumImport[:0]
 		scope, _, err := golang.BuildRefScope(g.utils, ast)


### PR DESCRIPTION
[kitex 支持了 no-recurse](https://github.com/cloudwego/kitex/commit/4eda40c008257ed02c6a08f58a52b679ee421910)，这个插件也兼容支持 recursive 参数

```bash
  -no-recurse
    	Don't generate thrift files recursively, just generate the given file.'
```